### PR TITLE
Add Makah (Qʷi·qʷidiččaq)

### DIFF
--- a/docu
+++ b/docu
@@ -129,6 +129,10 @@ Kwak’wala - http://www.firstvoices.com/en/Kwakwala/welcome
 Welcome to the language culture of the Kwakwa̱ka̱'wakw First Nations. We are the Kwak̓wala-speaking people on the north east coast of Vancouver Island and the adjacent mainland coast of British Columbia.
 a a̱ b d dł dz e g gw ǥ ǥw h i k kw k̓ k̕w ḵ ḵw ḵ̓ ḵ̕w l ł m n o p p̓ s t t̕ ts t̕s tł t̕ł u w x xw x̱ x̱w y ' 
 
+Qʷi·qʷi·diččaq (Makah) – https://makahmuseum.com/departments/makah-language-program/
+Qʷi·qʷidiččaq ‘Makah Language’ or ‘speaking Makah’ belongs to the Wakashan language family, specifically Southern Wakashan and is the ancestral language of the Makah Tribe in Neah Bay, Washington. Our language is related to the languages spoken by Ditidaht, Pacheedaht and Nuu-chah-nulth First Nations located on the west coast of Vancouver Island, B.C., Canada. 
+a a· b c č c̓ č̓ d e e· g h ḥ i j k kʷ k̓ k̓ʷ l ƛ ƛ̓ ɫ m n ŋ o o· p p̓ q qʷ q̓ q̓ʷ s š t t̓ u u· w x x̌ y z Ɂ
+
 
 INTERIOR
 Shuswap - http://www.languagegeek.com/salishan/secwepemctsin.html

--- a/docu
+++ b/docu
@@ -131,7 +131,8 @@ a a̱ b d dł dz e g gw ǥ ǥw h i k kw k̓ k̕w ḵ ḵw ḵ̓ ḵ̕w l ł m n 
 
 Qʷi·qʷi·diččaq (Makah) – https://makahmuseum.com/departments/makah-language-program/
 Qʷi·qʷidiččaq ‘Makah Language’ or ‘speaking Makah’ belongs to the Wakashan language family, specifically Southern Wakashan and is the ancestral language of the Makah Tribe in Neah Bay, Washington. Our language is related to the languages spoken by Ditidaht, Pacheedaht and Nuu-chah-nulth First Nations located on the west coast of Vancouver Island, B.C., Canada. 
-a a· b c č c̓ č̓ d e e· g h ḥ i j k kʷ k̓ k̓ʷ l ƛ ƛ̓ ɫ m n ŋ o o· p p̓ q qʷ q̓ q̓ʷ s š t t̓ u u· w x x̌ y z Ɂ
+a a· b c č c̓ č̓ d e e· g h ḥ i i· j k kʷ k̓ k̓ʷ l ƛ ƛ̓ ɫ m n  ŋ  o o· p p̓ q q q̓ q̓ʷ s š t t̓ u u· w x x̌ y z ʔ
+A A· B C Č C̓ Č̓ D E E· G H Ḥ I I· J K Kʷ K̓ k̓ʷ L ƛ ƛ̓ Ɫ M N (ŋ) O O· P P̓ Q Q Q̓ Q̓ʷ S Š T T̓ U U· W X X̌ Y Z ʔ
 
 
 INTERIOR


### PR DESCRIPTION
This adds the alphabet for the Makah language, a Wakashan language closely related to Nuu-chah-nulth and Ditidaht.

I have been working with the community on keyboards (see: https://keyman.com/keyboards/nrc_makah) and this seems to be the cannonical set of characters used to type the language. I have also made a small font test application that tries the Makah alphabet in various fonts availabe in Google Docs: https://makah-fonts.vercel.app/

The biggest stuggle I face with the community is getting computers to render «x̌» and «ƛ̓» properly!